### PR TITLE
Component.json removal

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,8 +1,0 @@
-{
-  "name": "mpath",
-  "version": "0.2.1",
-  "main": "lib/index.js",
-  "scripts": [
-    "lib/index.js"
-  ]
-}


### PR DESCRIPTION
Since https://github.com/componentjs/component is deprecated and component.json most likely is not used anywhere we could consider its removal.