### PR TITLE
Update Mocha again to 9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "benchmark": "~2.1.4",
     "eslint": "^7.16.0",
     "nyc": "^15.1.0",
-    "mocha": "5.x",
+    "mocha": "^9.2.2",
     "typescript": "^4.7.4",
     "eslint-plugin-mocha-no-only": "^1.1.1"
   }


### PR DESCRIPTION
**Summary**

This PR updates mocha again (by reverting 14de62742b495c29fcfd1d33055dcd6863f567e4), because 2c9a79bd2b46412ad10549dd74e3cea6a4d9ba98 updated the nodejs version which should make it compatible