### PR TITLE
Support mpath unset for arrays

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -129,38 +129,36 @@ exports.has = function has(path, o) {
  * @param {Object} o
  */
 
-exports.unset = function unset(path, o) {
+exports.unset = function(path, o) {
 
   if (o === null) return false;
 
   const parts = getPartsByPath(path),
       len = parts.length,
       last = len - 1;
-  let cur = o,
-      i = 0,
-      part = '';
 
-  for (i = 0; i < len; ++i) {
-    part = parts[i];
-    if (
-      ignoreProperties.has(part) ||
-      typeof cur !== 'object' ||
-      cur === null ||
-      !(part in cur)
-    ) {
-      return false;
-    }
+  return _unsetNext(o, '', 0, last);
+};
 
-    if (i === last) {
-      return delete cur[part];
-    }
-    cur = cur instanceof Map
-      ? cur.get(part)
-      : cur[part];
+function _unsetNext(cur, parts, i, last) {
+  const part = parts[i];
+
+  if (
+    ignoreProperties.has(part) ||
+    !((typeof cur === 'object' && (part in cur)) || Array.isArray(cur)) ||
+    cur === null 
+  ) {
+    return false;
   }
 
-  return true;
-};
+  if (i === last) {
+    return delete cur[part];
+  } else if (Array.isArray(cur[part])) {
+    return cur[parts[i]].reduce((acc, next) => acc && _unsetNext(next, parts, i + 1, last), true)
+  } else {
+    return _unsetNext(cur instanceof Map ? cur.get(part) : cur[part], parts, i + 1, last);
+  }
+}
 
 /**
  * Sets the `val` at the given `path` of object `o`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -134,10 +134,9 @@ exports.unset = function(path, o) {
   if (o === null) return false;
 
   const parts = getPartsByPath(path),
-      len = parts.length,
-      last = len - 1;
+      last = parts.length - 1;
 
-  return _unsetNext(o, '', 0, last);
+  return _unsetNext(o, parts, 0, last);
 };
 
 function _unsetNext(cur, parts, i, last) {
@@ -145,8 +144,8 @@ function _unsetNext(cur, parts, i, last) {
 
   if (
     ignoreProperties.has(part) ||
-    !((typeof cur === 'object' && (part in cur)) || Array.isArray(cur)) ||
-    cur === null 
+    !((typeof cur === 'object' && cur !== null && part in cur) || Array.isArray(cur)) ||
+    cur === null
   ) {
     return false;
   }
@@ -154,7 +153,7 @@ function _unsetNext(cur, parts, i, last) {
   if (i === last) {
     return delete cur[part];
   } else if (Array.isArray(cur[part])) {
-    return cur[parts[i]].reduce((acc, next) => acc && _unsetNext(next, parts, i + 1, last), true)
+    return cur[parts[i]].reduce((acc, next) => acc && _unsetNext(next, parts, i + 1, last), true);
   } else {
     return _unsetNext(cur instanceof Map ? cur.get(part) : cur[part], parts, i + 1, last);
   }

--- a/test/index.js
+++ b/test/index.js
@@ -1903,6 +1903,10 @@ describe('mpath', function() {
       mpath.unset('a.b', o);
       assert.deepEqual(o, { a: {} });
 
+      o = { a: [{ b: 1 }, { b: 2 }] };
+      mpath.unset('a.b', o);
+      assert.deepEqual(o, { a: [{}, {}] });
+
       o = { a: null };
       mpath.unset('a.b', o);
       assert.deepEqual(o, { a: null });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.-->

**Summary**

The current implementation of `unset` does not have the same behaviour as set/get as it does not follow paths down arrays. This PR implements unset to work on arrays as well, mimicing the behaviour of set/unset

**Examples**

See test file